### PR TITLE
only send js options to ComScore

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,8 @@ var Comscore = module.exports = integration('comScore')
  */
 
 Comscore.prototype.initialize = function() {
-  window._comscore = window._comscore || [this.options];
+  var comScoreOptions = { c1: this.options.c1, c2: this.options.c2 };
+  window._comscore = window._comscore || [comScoreOptions];
   var tagName = useHttps() ? 'https' : 'http';
   this.load(tagName, this.ready);
 };
@@ -51,5 +52,6 @@ Comscore.prototype.loaded = function() {
  */
 
 Comscore.prototype.page = function() {
-  window.COMSCORE.beacon(this.options);
+  var comScoreOptions = { c1: this.options.c1, c2: this.options.c2 };
+  window.COMSCORE.beacon(comScoreOptions);
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,7 +10,8 @@ describe('comScore', function() {
   var analytics;
   var comscore;
   var options = {
-    c2: 'x'
+    c2: 'x',
+    autoUpdateInterval: ''
   };
 
   beforeEach(function() {


### PR DESCRIPTION
We were passing comscore the entire options object which was passing along options that only matter to the mobile integrations.

This PR changes this so we only send the options parameters that make sense for their JS integration.
